### PR TITLE
Allow MediaGalleryEntrySet to become optional and set to null by default

### DIFF
--- a/src/MediaGalleryEntry.php
+++ b/src/MediaGalleryEntry.php
@@ -103,12 +103,10 @@ final class MediaGalleryEntry implements ValueObject
             (empty(array_diff($this->types, $object->types)) && empty(array_diff($object->types, $this->types)));
     }
 
-    public function fromJson($json): MediaGalleryEntry
+    public static function fromJson($json): MediaGalleryEntry
     {
-        return self::create()
-            ->withMediaType($json['media_type'])
+        return self::of($json['media_type'], $json['label'])
             ->withFile($json['file'])
-            ->withLabel($json['label'])
             ->withDisabled($json['disabled'])
             ->withTypes($json['types'])
             ->withPosition($json['position']);

--- a/src/ProductData.php
+++ b/src/ProductData.php
@@ -206,18 +206,15 @@ final class ProductData implements ValueObject
             'price' => $this->price,
             'type_id' => $this->typeId,
             'weight' => $this->weight,
+            'extension_attributes' => $this->extensionAttributes->toJson(),
+            'custom_attributes' => $this->customAttributes->toJson(),
+            'tier_prices' => $this->tierPrices->toJson(),
+            'product_links' => $this->productLinks->toJson()
         ];
 
         if ($this->mediaGalleryEntries !== null) {
             $json['media_gallery_entries'] = $this->mediaGalleryEntries->toJson();
         }
-
-        $json += [
-            'extension_attributes' => $this->extensionAttributes->toJson(),
-            'custom_attributes' => $this->customAttributes->toJson(),
-            'tier_prices' => $this->tierPrices->toJson(),
-            'product_links' => $this->productLinks->toJson(),
-        ];
 
         return $json;
     }

--- a/src/ProductData.php
+++ b/src/ProductData.php
@@ -13,7 +13,6 @@ final class ProductData implements ValueObject
     {
         $productData = new self($sku, $name);
         $productData->customAttributes = CustomAttributeSet::create();
-        $productData->mediaGalleryEntries = MediaGalleryEntrySet::create();
         $productData->tierPrices = TierPriceSet::create();
         $productData->productLinks = ProductLinkSet::create();
 
@@ -154,7 +153,7 @@ final class ProductData implements ValueObject
         return $result;
     }
 
-    public function getMediaGalleryEntries(): MediaGalleryEntrySet
+    public function getMediaGalleryEntries(): ?MediaGalleryEntrySet
     {
         return $this->mediaGalleryEntries;
     }
@@ -166,7 +165,7 @@ final class ProductData implements ValueObject
         return $result;
     }
 
-    public function withMediaGalleryEntries(MediaGalleryEntrySet $mediaGalleryEntries): self
+    public function withMediaGalleryEntries(?MediaGalleryEntrySet $mediaGalleryEntries): self
     {
         $result = clone $this;
         $result->mediaGalleryEntries = $mediaGalleryEntries;
@@ -199,7 +198,7 @@ final class ProductData implements ValueObject
 
     public function toJson(): array
     {
-        return [
+        $json = [
             'sku' => $this->sku,
             'name' => $this->name,
             'status' => (int)$this->status,
@@ -207,12 +206,20 @@ final class ProductData implements ValueObject
             'price' => $this->price,
             'type_id' => $this->typeId,
             'weight' => $this->weight,
-            'media_gallery_entries' => $this->mediaGalleryEntries->toJson(),
+        ];
+
+        if ($this->mediaGalleryEntries !== null) {
+            $json['media_gallery_entries'] = $this->mediaGalleryEntries->toJson();
+        }
+
+        $json += [
             'extension_attributes' => $this->extensionAttributes->toJson(),
             'custom_attributes' => $this->customAttributes->toJson(),
             'tier_prices' => $this->tierPrices->toJson(),
             'product_links' => $this->productLinks->toJson(),
         ];
+
+        return $json;
     }
 
     public function equals($otherProductData): bool

--- a/src/SetTrait.php
+++ b/src/SetTrait.php
@@ -4,7 +4,6 @@ namespace SnowIO\Magento2DataModel;
 
 trait SetTrait
 {
-
     /**
      * @return static
      */

--- a/test/unit/Command/SaveProductCommandTest.php
+++ b/test/unit/Command/SaveProductCommandTest.php
@@ -30,7 +30,6 @@ class SaveProductCommandTest extends TestCase
                     'attribute_set_code' => 'default'
                 ],
                 'custom_attributes' => [],
-                'media_gallery_entries' => [],
                 'tier_prices' => [],
                 'product_links' => [],
             ]

--- a/test/unit/MediaGalleryEntrySetTest.php
+++ b/test/unit/MediaGalleryEntrySetTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace  SnowIO\Magento2DataModel\Test;
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Magento2DataModel\MediaGalleryEntry;
+use SnowIO\Magento2DataModel\MediaGalleryEntrySet;
+
+class MediaGalleryEntrySetTest extends TestCase
+{
+    public function testToJson()
+    {
+        $mediaGallerySet = MediaGalleryEntrySet::create()
+            ->withMediaGalleryEntry(MediaGalleryEntry::of('image', 'Label')
+                ->withTypes(['image', 'small_image', 'thumbnail'])
+                ->withFile('path/image.jpg'));
+
+        self::assertSame(1, $mediaGallerySet->count());
+        self::assertEquals([
+            [
+                'media_type' => 'image',
+                'label' => 'Label',
+                'position' => 0,
+                'disabled' => false,
+                'types' => [
+                    'image', 'small_image', 'thumbnail'
+                ],
+                'file' => 'path/image.jpg',
+            ]
+        ], $mediaGallerySet->toJson());
+    }
+
+    public function testWitherToSet()
+    {
+        $mediaGallerySet = MediaGalleryEntrySet::create();
+        self::assertTrue($mediaGallerySet->isEmpty());
+
+        $mediaGallerySet = $mediaGallerySet
+            ->withMediaGalleryEntry(MediaGalleryEntry::of('mediatype1', 'label1'))
+            ->withMediaGalleryEntry(MediaGalleryEntry::of('mediatype1', 'label2'));
+
+        self::assertEquals(2, $mediaGallerySet->count());
+    }
+
+    public function testEquality()
+    {
+        $expectedMediaGalleryEntrySet = MediaGalleryEntrySet::create()
+            ->withMediaGalleryEntry(
+                MediaGalleryEntry::of('test1', 'a')
+                    ->withTypes(['image', 'small_image', 'thumbnail'])
+                    ->withFile('path/image.jpg')
+                    ->withDisabled(false)
+                    ->withPosition(1)
+            );
+
+        $differentMediaGalleryEntrySet = MediaGalleryEntrySet::create()
+            ->withMediaGalleryEntry(
+                MediaGalleryEntry::of('test1', 'a')
+                ->withTypes(['image', 'small_image', 'thumbnail'])
+                ->withFile('path/image2.jpg')
+                ->withDisabled(false)
+                ->withPosition(1)
+            );
+
+        self::assertTrue($expectedMediaGalleryEntrySet->equals(clone $expectedMediaGalleryEntrySet));
+        self::assertFalse($expectedMediaGalleryEntrySet->equals($differentMediaGalleryEntrySet));
+    }
+}

--- a/test/unit/MediaGalleryEntryTest.php
+++ b/test/unit/MediaGalleryEntryTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+namespace  SnowIO\Magento2DataModel\Test;
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Magento2DataModel\MediaGalleryEntry;
+
+class MediaGalleryEntryTest extends TestCase
+{
+    public function testToJson()
+    {
+        $mediaGallery = MediaGalleryEntry::of('image', 'Label')
+            ->withFile('path/image.jpg')
+            ->withTypes(['image', 'small_image', 'thumbnail']);
+
+        $this->assertEquals([
+                'media_type' => 'image',
+                'label' => 'Label',
+                'position' => 0,
+                'disabled' => false,
+                'file' => 'path/image.jpg',
+                'types' => ['image', 'small_image', 'thumbnail']
+        ], $mediaGallery->toJson());
+    }
+
+    public function testFromJson()
+    {
+        $mediaGallery = MediaGalleryEntry::fromJson([
+            'media_type' => 'image',
+            'label' => 'Label',
+            'position' => 0,
+            'disabled' => false,
+            'file' => 'path/image.jpg',
+            'types' => ['image', 'small_image', 'thumbnail']
+        ]);
+
+        $this->assertEquals([
+            'media_type' => 'image',
+            'label' => 'Label',
+            'position' => 0,
+            'disabled' => false,
+            'file' => 'path/image.jpg',
+            'types' => ['image', 'small_image', 'thumbnail']
+        ], $mediaGallery->toJson());
+    }
+
+    public function testAccessors()
+    {
+        $mediaGallery = MediaGalleryEntry::of('image', 'Label');
+
+        $this->assertEquals('image', $mediaGallery->getMediaType());
+        $this->assertEquals('Label', $mediaGallery->getLabel());
+        $this->assertEquals(0, $mediaGallery->getDisabled());
+        $this->assertEquals(0, $mediaGallery->getPosition());
+        $this->assertEquals(null, $mediaGallery->getFile());
+        $this->assertEquals([], $mediaGallery->getTypes());
+
+        $mediaGallery = MediaGalleryEntry::of('image', 'Label')
+            ->withFile('path/image.jpg')
+            ->withTypes(['image', 'small_image', 'thumbnail'])
+            ->withDisabled(true)
+            ->withPosition(1);
+
+        $this->assertEquals(1, $mediaGallery->getDisabled());
+        $this->assertEquals(1, $mediaGallery->getPosition());
+        $this->assertEquals('path/image.jpg', $mediaGallery->getFile());
+        $this->assertEquals(['image', 'small_image', 'thumbnail'], $mediaGallery->getTypes());
+    }
+
+    public function testEquals()
+    {
+        $mediaGallery = MediaGalleryEntry::fromJson([
+            'media_type' => 'image',
+            'label' => 'Label',
+            'position' => 0,
+            'disabled' => false,
+            'file' => 'path/image.jpg',
+            'types' => ['image', 'small_image', 'thumbnail']
+        ]);
+
+        $mediaGallery2 = MediaGalleryEntry::of('image', 'Label')
+            ->withFile('path/image.jpg')
+            ->withTypes(['image', 'small_image', 'thumbnail'])
+            ->withDisabled(false)
+            ->withPosition(0);
+
+        $this->assertTrue($mediaGallery->equals($mediaGallery2));
+    }
+}

--- a/test/unit/ProductDataTest.php
+++ b/test/unit/ProductDataTest.php
@@ -89,7 +89,7 @@ class ProductDataTest extends TestCase
             ->withAttributeSetCode('TestAttributeSet')
             ->withStoreCode('default')
             ->withStockItem(StockItem::of(1, 300))
-            ->withTierPrices(TierPriceSet::of([TierPrice::of(1,1,'100')]))
+            ->withTierPrices(TierPriceSet::of([TierPrice::of(1, 1, '100')]))
             ->withProductLinks(ProductLinkSet::create()->withProductLink(
                 ProductLink::of('KEY', 'x', 'type')
             ))
@@ -105,7 +105,7 @@ class ProductDataTest extends TestCase
             ]));
 
         self::assertSame(
-            TierPriceSet::of([TierPrice::of(1,1,'100')])->toJson(),
+            TierPriceSet::of([TierPrice::of(1, 1, '100')])->toJson(),
             $product->getTierPrices()->toJson()
         );
         self::assertSame(
@@ -148,8 +148,7 @@ class ProductDataTest extends TestCase
             ->withMediaGalleryEntries(MediaGalleryEntrySet::create()
                 ->withMediaGalleryEntry(MediaGalleryEntry::of('image', 'Label')
                     ->withTypes(['image', 'small_image', 'thumbnail'])
-                    ->withFile('path/image.jpg')
-                ));
+                    ->withFile('path/image.jpg')));
 
         self::assertEquals([
             'sku' => 'snowio-test-product',
@@ -169,6 +168,29 @@ class ProductDataTest extends TestCase
                     'types' => ['image', 'small_image', 'thumbnail']
                 ]
             ],
+            'extension_attributes' => [
+                'attribute_set_code' => 'default'
+            ],
+            'custom_attributes' => [],
+            'tier_prices' => [],
+            'product_links' => [],
+        ], $product->toJson());
+    }
+
+    public function testWithEmptyMediaGalleryEntrySet()
+    {
+        $product = ProductData::of('snowio-test-product', 'Snowio Test Product')
+            ->withMediaGalleryEntries(MediaGalleryEntrySet::create());
+
+        self::assertEquals([
+            'sku' => 'snowio-test-product',
+            'name' => 'Snowio Test Product',
+            'status' => ProductStatus::ENABLED,
+            'visibility' => ProductVisibility::CATALOG_SEARCH,
+            'price' => null,
+            'weight' => null,
+            'type_id' => 'simple',
+            'media_gallery_entries' => [],
             'extension_attributes' => [
                 'attribute_set_code' => 'default'
             ],

--- a/test/unit/ProductDataTest.php
+++ b/test/unit/ProductDataTest.php
@@ -9,6 +9,8 @@ use SnowIO\Magento2DataModel\CustomAttributeSet;
 use SnowIO\Magento2DataModel\EavEntityTrait;
 use SnowIO\Magento2DataModel\ExtensionAttribute;
 use SnowIO\Magento2DataModel\ExtensionAttributeSet;
+use SnowIO\Magento2DataModel\MediaGalleryEntry;
+use SnowIO\Magento2DataModel\MediaGalleryEntrySet;
 use SnowIO\Magento2DataModel\ProductData;
 use SnowIO\Magento2DataModel\ProductLink;
 use SnowIO\Magento2DataModel\ProductLinkSet;
@@ -36,7 +38,6 @@ class ProductDataTest extends TestCase
                 'attribute_set_code' => 'default'
             ],
             'custom_attributes' => [],
-            'media_gallery_entries' => [],
             'tier_prices' => [],
             'product_links' => [],
         ], $product->toJson());
@@ -51,10 +52,10 @@ class ProductDataTest extends TestCase
         self::assertEquals(ProductVisibility::CATALOG_SEARCH, $product->getVisibility());
         self::assertEquals(null, $product->getPrice());
         self::assertEquals(null, $product->getWeight());
+        self::assertEquals(null, $product->getMediaGalleryEntries());
         self::assertEquals(ProductTypeId::SIMPLE, $product->getTypeId());
         self::assertEquals(ProductData::DEFAULT_ATTRIBUTE_SET_CODE, $product->getAttributeSetCode());
         self::assertTrue(($product->getCustomAttributes())->isEmpty());
-        self::assertTrue(($product->getMediaGalleryEntries())->isEmpty());
         self::assertTrue(($product->getTierPrices())->isEmpty());
         self::assertTrue(($product->getProductLinks())->isEmpty());
     }
@@ -139,6 +140,42 @@ class ProductDataTest extends TestCase
             ->withCustomAttribute(CustomAttribute::of('height', '250'))
             ->withCustomAttribute(CustomAttribute::of('density', '800'));
         self::assertTrue($product->getCustomAttributes()->equals($expectedCustomAttributes));
+    }
+
+    public function testWithMediaGalleryEntrySet()
+    {
+        $product = ProductData::of('snowio-test-product', 'Snowio Test Product')
+            ->withMediaGalleryEntries(MediaGalleryEntrySet::create()
+                ->withMediaGalleryEntry(MediaGalleryEntry::of('image', 'Label')
+                    ->withTypes(['image', 'small_image', 'thumbnail'])
+                    ->withFile('path/image.jpg')
+                ));
+
+        self::assertEquals([
+            'sku' => 'snowio-test-product',
+            'name' => 'Snowio Test Product',
+            'status' => ProductStatus::ENABLED,
+            'visibility' => ProductVisibility::CATALOG_SEARCH,
+            'price' => null,
+            'weight' => null,
+            'type_id' => 'simple',
+            'media_gallery_entries' => [
+                [
+                    'media_type' => 'image',
+                    'label' => 'Label',
+                    'position' => 0,
+                    'disabled' => false,
+                    'file' => 'path/image.jpg',
+                    'types' => ['image', 'small_image', 'thumbnail']
+                ]
+            ],
+            'extension_attributes' => [
+                'attribute_set_code' => 'default'
+            ],
+            'custom_attributes' => [],
+            'tier_prices' => [],
+            'product_links' => [],
+        ], $product->toJson());
     }
 
     public function testWithCustomAttributeSet()


### PR DESCRIPTION
`media_gallery_entries` should be included in the product JSON only when we need to. An empty array will remove images in Magento.

This PR will allow the MediaGalleryEntrySet to become optional, so its not included in the JSON if its null (default).