### PR TITLE
Add attribute_set_id to Product Model

### DIFF
--- a/src/ExtensionAttributeSet.php
+++ b/src/ExtensionAttributeSet.php
@@ -14,6 +14,14 @@ final class ExtensionAttributeSet implements \IteratorAggregate, ValueObject
         return $result;
     }
 
+    public function deleteExtensionAttribute(ExtensionAttribute $extensionAttribute): self
+    {
+        $result = clone $this;
+        $key = self::getKey($extensionAttribute);
+        unset($result->items[$key]);
+        return $result;
+    }
+
     public function get(string $key): ?ExtensionAttribute
     {
         return $this->items[$key] ?? null;

--- a/src/ProductData.php
+++ b/src/ProductData.php
@@ -112,10 +112,21 @@ final class ProductData implements ValueObject
     public function withAttributeSetCode(string $attributeSetCode): self
     {
         $result = clone $this;
+        $result->attributeSetId = null;
         $result->extensionAttributes = $result->extensionAttributes
             ->withExtensionAttribute(
                 ExtensionAttribute::of(self::ATTRIBUTE_SET_CODE, $attributeSetCode)
             );
+        return $result;
+    }
+
+    public function withAttributeSetId(int $attributeSetId): self
+    {
+        $result = clone $this;
+        $result->attributeSetId = $attributeSetId;
+        $result->extensionAttributes = $result->extensionAttributes->deleteExtensionAttribute(
+            ExtensionAttribute::of(self::ATTRIBUTE_SET_CODE, null)
+        );
         return $result;
     }
 
@@ -216,6 +227,9 @@ final class ProductData implements ValueObject
             $json['media_gallery_entries'] = $this->mediaGalleryEntries->toJson();
         }
 
+        if ($this->attributeSetId !== null) {
+            $json['attribute_set_id'] = (int) $this->attributeSetId;
+        }
         return $json;
     }
 
@@ -246,6 +260,7 @@ final class ProductData implements ValueObject
     private $mediaGalleryEntries;
     private $tierPrices;
     private $productLinks;
+    private $attributeSetId;
 
     private function __construct(string $sku, string $name)
     {

--- a/src/SetTrait.php
+++ b/src/SetTrait.php
@@ -81,6 +81,16 @@ trait SetTrait
     /**
      * @return static
      */
+    public function delete($key): self
+    {
+        $result = new self;
+        unset($this->items[$key]);
+        return $result;
+    }
+
+    /**
+     * @return static
+     */
     public function merge(self $otherSet): self
     {
         $result = new self;

--- a/test/unit/ExtensionAttributeSetTest.php
+++ b/test/unit/ExtensionAttributeSetTest.php
@@ -66,6 +66,17 @@ class ExtensionAttributeSetTest extends TestCase
         self::assertFalse($expectedExtensionAttributeSet->equals($differentExtensionAttributeSet));
     }
 
+    public function testDeleteExtensionAttributeByKey()
+    {
+        $extensionAttributeSet = ExtensionAttributeSet::of([
+            ExtensionAttribute::of('attribute_test_1', 'general'),
+            ExtensionAttribute::of('attribute_test_2', 'general'),
+        ]);
+        $extensionAttributeSet->delete('attribute_test_1');
+
+        self::assertSame(1, $extensionAttributeSet->count());
+    }
+
     public function testGet()
     {
         $extensionAttributeSet = ExtensionAttributeSet::of([

--- a/test/unit/ProductDataTest.php
+++ b/test/unit/ProductDataTest.php
@@ -200,7 +200,80 @@ class ProductDataTest extends TestCase
         ], $product->toJson());
     }
 
-    public function testWithCustomAttributeSet()
+    /**
+     * When attribute_set_id is defined, the default attribute_set_code is removed due to BC
+     */
+    public function testWithAttributeSetId()
+    {
+        $product = ProductData::of('snowio-test-product', 'Snowio Test Product')
+            ->withAttributeSetId(99)
+            ->withExtensionAttribute(ExtensionAttribute::of('not_attribute_set_code', 'should_keep'));
+
+        self::assertEquals([
+            'sku' => 'snowio-test-product',
+            'name' => 'Snowio Test Product',
+            'status' => ProductStatus::ENABLED,
+            'visibility' => ProductVisibility::CATALOG_SEARCH,
+            'price' => null,
+            'weight' => null,
+            'type_id' => 'simple',
+            'attribute_set_id' => 99,
+            'extension_attributes' => [
+                'not_attribute_set_code' => 'should_keep'
+            ],
+            'custom_attributes' => [],
+            'tier_prices' => [],
+            'product_links' => [],
+        ], $product->toJson());
+    }
+
+    public function testWithoutAttributeSetId()
+    {
+        $product = ProductData::of('snowio-test-product', 'Snowio Test Product');
+
+        self::assertEquals([
+            'sku' => 'snowio-test-product',
+            'name' => 'Snowio Test Product',
+            'status' => ProductStatus::ENABLED,
+            'visibility' => ProductVisibility::CATALOG_SEARCH,
+            'price' => null,
+            'weight' => null,
+            'type_id' => 'simple',
+            'extension_attributes' => [
+                'attribute_set_code' => 'default'
+            ],
+            'custom_attributes' => [],
+            'tier_prices' => [],
+            'product_links' => [],
+        ], $product->toJson());
+    }
+
+    public function testShouldRemoveAttributeSetId()
+    {
+        $product2 = ProductData::of('snowio-test-product', 'Snowio Test Product')
+            ->withAttributeSetId(99)
+            ->withExtensionAttribute(ExtensionAttribute::of('not_attribute_set_code', 'should_keep'))
+            ->withAttributeSetCode('default');
+
+        self::assertEquals([
+            'sku' => 'snowio-test-product',
+            'name' => 'Snowio Test Product',
+            'status' => ProductStatus::ENABLED,
+            'visibility' => ProductVisibility::CATALOG_SEARCH,
+            'price' => null,
+            'weight' => null,
+            'type_id' => 'simple',
+            'extension_attributes' => [
+                'attribute_set_code' => 'default',
+                'not_attribute_set_code' => 'should_keep'
+            ],
+            'custom_attributes' => [],
+            'tier_prices' => [],
+            'product_links' => [],
+        ], $product2->toJson());
+    }
+
+        public function testWithCustomAttributeSet()
     {
         $product = ProductData::of('snowio-test-product', 'Snowio Test Product Updated!!')
             ->withCustomAttributes(CustomAttributeSet::of([


### PR DESCRIPTION
We should be able to use attribute_set_id for projects that snow will not manage attribute sets.

New features:
- Allow user to specify attribute_set_id, 
   * when the attribute_set_id is used, the default attribute_set_code is removed. This feature is not required since the api endpoint will use attribute_set_id instead of code. This is just for consistency.
- The other way around is also true, when attributeSetCode is used, we remove attribute_set_id.