### PR TITLE
Add config back orders

### DIFF
--- a/src/ExtensionAttribute.php
+++ b/src/ExtensionAttribute.php
@@ -32,11 +32,11 @@ class ExtensionAttribute implements ValueObject
         return $this->value;
     }
 
-    public function equals($extensionAttribute): bool
+    public function equals($other): bool
     {
-        return $extensionAttribute instanceof ExtensionAttribute
-            && $extensionAttribute->code === $this->code
-            && $extensionAttribute->value === $this->value;
+        return $other instanceof ExtensionAttribute
+            && $other->code === $this->code
+            && $other->value === $this->value;
     }
 
     private $code;

--- a/src/StockItem.php
+++ b/src/StockItem.php
@@ -78,14 +78,27 @@ final class StockItem implements ValueObject
         return $result;
     }
 
-    public function equals($extensionAttribute): bool
+    public function withUseConfigBackorders(bool $useConfigBackorders): self
     {
-        return ($extensionAttribute instanceof StockItem) &&
-            ($this->stockId === $extensionAttribute->stockId) &&
-            ($this->quantity === $extensionAttribute->quantity) &&
-            ($this->isInStock === $extensionAttribute->isInStock) &&
-            ($this->manageStock === $extensionAttribute->manageStock) &&
-            ($this->useConfigManageStock === $extensionAttribute->useConfigManageStock);
+        $result = clone $this;
+        $result->useConfigBackorders = $useConfigBackorders;
+        return $result;
+    }
+
+    public function getUseConfigBackorders(): bool
+    {
+        return $this->useConfigBackorders;
+    }
+
+    public function equals($other): bool
+    {
+        return ($other instanceof StockItem) &&
+            ($this->stockId === $other->stockId) &&
+            ($this->quantity === $other->quantity) &&
+            ($this->isInStock === $other->isInStock) &&
+            ($this->manageStock === $other->manageStock) &&
+            ($this->useConfigBackorders === $other->useConfigBackorders) &&
+            ($this->useConfigManageStock === $other->useConfigManageStock);
     }
 
     public static function fromJson(array $json)
@@ -121,6 +134,9 @@ final class StockItem implements ValueObject
         if (isset($this->useConfigManageStock)) {
             $json['use_config_manage_stock'] = $this->useConfigManageStock;
         }
+        if (isset($this->useConfigBackorders)) {
+            $json['use_config_backorders'] = $this->useConfigBackorders;
+        }
         return $json;
     }
 
@@ -133,6 +149,7 @@ final class StockItem implements ValueObject
     private $quantity;
     private $isInStock;
     private $manageStock;
+    private $useConfigBackorders;
     private $useConfigManageStock;
 
     protected function __construct()

--- a/test/unit/StockItemTest.php
+++ b/test/unit/StockItemTest.php
@@ -19,11 +19,13 @@ class StockItemTest extends TestCase
 
         $stockItem = $stockItem
             ->withInStock(true)
+            ->withUseConfigBackorders(true)
             ->withManageStock(false);
 
         self::assertEquals([
             'stock_id' => 1,
             'qty' => 100,
+            'use_config_backorders' => true,
             'is_in_stock' => true,
             'manage_stock' => false,
         ], $stockItem->toJson());
@@ -40,6 +42,9 @@ class StockItemTest extends TestCase
 
         $stockItem = $stockItem->withQuantity(1000);
         self::assertEquals(1000, $stockItem->getQuantity());
+
+        $stockItem = $stockItem->withUseConfigBackorders(true);
+        self::assertEquals(true, $stockItem->getUseConfigBackorders());
     }
 
     public function testEquals()
@@ -48,6 +53,7 @@ class StockItemTest extends TestCase
         self::assertTrue($stockItem->equals(StockItem::of(1, 100)));
         self::assertFalse($stockItem->equals(StockItem::of(1, 1000)));
         self::assertFalse($stockItem->equals(StockItem::of(10, 100)));
+        self::assertFalse($stockItem->equals(StockItem::of(1, 100)->withUseConfigBackorders(true)));
         self::assertFalse($stockItem->equals(ExtensionAttribute::of('stock_size', 1000)));
         self::assertFalse($stockItem->equals(ExtensionAttribute::of('stock_item', 100)));
     }


### PR DESCRIPTION
## Overview 

PR aims to add back order configuration to stock items. The field can be found in the extension attribute section of the catalog product save json api https://devdocs.magento.com/swagger/index.html#/catalogProductRepositoryV1/catalogProductRepositoryV1SavePost