### PR TITLE
Store labels and Sort Order

### DIFF
--- a/src/AttributeOption.php
+++ b/src/AttributeOption.php
@@ -75,7 +75,8 @@ final class AttributeOption implements ValueObject
         return $attributeOption instanceof AttributeOption &&
             ($this->attributeCode === $attributeOption->attributeCode) &&
             ($this->value === $attributeOption->value) &&
-            ($this->label === $attributeOption->label);
+            ($this->label === $attributeOption->label) &&
+            ($this->storeLabels->equals($attributeOption->storeLabels));
     }
 
     private $attributeCode;

--- a/src/AttributeOption.php
+++ b/src/AttributeOption.php
@@ -76,6 +76,7 @@ final class AttributeOption implements ValueObject
             ($this->attributeCode === $attributeOption->attributeCode) &&
             ($this->value === $attributeOption->value) &&
             ($this->label === $attributeOption->label) &&
+            ($this->sortOrder === $attributeOption->sortOrder) &&
             ($this->storeLabels->equals($attributeOption->storeLabels));
     }
 

--- a/src/AttributeOption.php
+++ b/src/AttributeOption.php
@@ -34,9 +34,23 @@ final class AttributeOption implements ValueObject
         return $result;
     }
 
+    public function withStoreLabels(AttributeOptionStoreLabelSet $storeLabels)
+    {
+        $result = clone $this;
+        $result->storeLabels = $storeLabels;
+        return $result;
+    }
+
+    public function withSortOrder(int $sortOrder)
+    {
+        $result = clone $this;
+        $result->sortOrder = $sortOrder;
+        return $result;
+    }
+
     public function toJson(): array
     {
-        return [
+        $json = [
             'entity_type' => self::PRODUCT_ENTITY_TYPE,
             'attribute_code' => $this->attributeCode,
             'option' => [
@@ -44,6 +58,16 @@ final class AttributeOption implements ValueObject
                 'label' => $this->label,
             ],
         ];
+
+        if ($this->sortOrder) {
+            $json['option']['sort_order'] = $this->sortOrder;
+        }
+
+        if (!$this->storeLabels->isEmpty()) {
+            $json['option']['store_labels'] =  $this->storeLabels->toJson();
+        }
+
+        return $json;
     }
 
     public function equals($attributeOption): bool
@@ -57,11 +81,14 @@ final class AttributeOption implements ValueObject
     private $attributeCode;
     private $value;
     private $label;
+    private $storeLabels;
+    private $sortOrder;
 
     private function __construct(string $attributeCode, string $value, string $label)
     {
         $this->attributeCode = $attributeCode;
         $this->value = $value;
         $this->label = $label;
+        $this->storeLabels = AttributeOptionStoreLabelSet::create();
     }
 }

--- a/src/AttributeOptionStoreLabel.php
+++ b/src/AttributeOptionStoreLabel.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+namespace SnowIO\Magento2DataModel;
+
+class AttributeOptionStoreLabel implements ValueObject
+{
+    public static function of(string $storeCode, string $label)
+    {
+        return new self($storeCode, $label);
+    }
+
+    public function getStoreCode()
+    {
+        return $this->storeCode;
+    }
+
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    public function toJson()
+    {
+        return [
+            'store_code' => $this->storeCode,
+            'label' => $this->label
+        ];
+    }
+
+    private $label;
+    private $storeCode;
+
+    private function __construct(string $storeCode, string $label)
+    {
+        $this->label = $label;
+        $this->storeCode = $storeCode;
+    }
+
+    public function equals($object): bool
+    {
+        return $object instanceof self &&
+            $object->label == $this->label &&
+            $object->storeCode == $this->storeCode;
+    }
+}

--- a/src/AttributeOptionStoreLabelSet.php
+++ b/src/AttributeOptionStoreLabelSet.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+namespace SnowIO\Magento2DataModel;
+
+final class AttributeOptionStoreLabelSet implements \IteratorAggregate, ValueObject
+{
+    use SetTrait;
+
+    public function with(AttributeOptionStoreLabel $attributeOptionStoreLabel): self
+    {
+        $result = clone $this;
+        $key = self::getKey($attributeOptionStoreLabel);
+        $result->items[$key] = $attributeOptionStoreLabel;
+        return $result;
+    }
+
+    private static function getKey(AttributeOptionStoreLabel $attributeOptionStoreLabel): string
+    {
+        return $attributeOptionStoreLabel->getStoreCode();
+    }
+
+    public function toJson(): array
+    {
+        return array_map(function (AttributeOptionStoreLabel $attributeOptionStoreLabel) {
+            return $attributeOptionStoreLabel->toJson();
+        }, array_values($this->items));
+    }
+
+
+    private static function itemsAreEqual(AttributeOptionStoreLabel $attributeOption, AttributeOptionStoreLabel $otherAttributeOption): bool
+    {
+        return $attributeOption->equals($otherAttributeOption);
+    }
+}

--- a/test/unit/AttributeOptionStoreLabelSetTest.php
+++ b/test/unit/AttributeOptionStoreLabelSetTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace SnowIO\Magento2DataModel\Test;
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Magento2DataModel\AttributeOptionStoreLabel;
+use SnowIO\Magento2DataModel\AttributeOptionStoreLabelSet;
+
+class AttributeOptionStoreLabelSetTest extends TestCase
+{
+    public function testWither()
+    {
+        $attributeOptionStoreLabelSet = AttributeOptionStoreLabelSet::of([
+            AttributeOptionStoreLabel::of('en_gb', "Large"),
+            AttributeOptionStoreLabel::of('de_de', "Gross")
+        ]);
+
+        $attributeOptionStoreLabelSet = $attributeOptionStoreLabelSet->with(
+            AttributeOptionStoreLabel::of("fr_fr", "Grand")
+        );
+
+        self::assertTrue($attributeOptionStoreLabelSet->equals(AttributeOptionStoreLabelSet::of([
+            AttributeOptionStoreLabel::of('en_gb', "Large"),
+            AttributeOptionStoreLabel::of('de_de', "Gross"),
+            AttributeOptionStoreLabel::of("fr_fr", "Grand"),
+        ])));
+    }
+}

--- a/test/unit/AttributeOptionStoreLabelTest.php
+++ b/test/unit/AttributeOptionStoreLabelTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace SnowIO\Magento2DataModel\Test;
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Magento2DataModel\AttributeOptionStoreLabel;
+
+class AttributeOptionStoreLabelTest extends TestCase
+{
+    public function testToJson()
+    {
+        $attributeOptionStoreLabel = AttributeOptionStoreLabel::of("en_gb", "Test");
+        self::assertEquals([
+            'store_code' => 'en_gb',
+            'label' => 'Test'
+        ], $attributeOptionStoreLabel->toJson());
+    }
+
+    public function testEquals()
+    {
+        $storeLabelA =  AttributeOptionStoreLabel::of("en_gb", "Test");
+        $sameAsA = $storeLabelA;
+        self::assertTrue($storeLabelA->equals($sameAsA));
+        self::assertFalse($storeLabelA->equals(AttributeOptionStoreLabel::of("en_gb", "Test2")));
+        self::assertFalse($storeLabelA->equals(AttributeOptionStoreLabel::of("eu_eu", "Test")));
+    }
+}

--- a/test/unit/AttributeOptionTest.php
+++ b/test/unit/AttributeOptionTest.php
@@ -5,18 +5,46 @@ namespace  SnowIO\Magento2DataModel\Test;
 use PHPUnit\Framework\TestCase;
 use SnowIO\Magento2DataModel\AttributeData;
 use SnowIO\Magento2DataModel\AttributeOption;
+use SnowIO\Magento2DataModel\AttributeOptionStoreLabel;
+use SnowIO\Magento2DataModel\AttributeOptionStoreLabelSet;
 
 class AttributeOptionTest extends TestCase
 {
     public function testToJson()
     {
-        $attributeOption = AttributeOption::of('size', 'large', 'Large');
+        $attributeOption = AttributeOption::of('size', 'large', 'Large')
+            ->withSortOrder(3)
+            ->withStoreLabels(AttributeOptionStoreLabelSet::of([
+                AttributeOptionStoreLabel::of('en_gb', 'Large'),
+                AttributeOptionStoreLabel::of('en_eu', 'Large'),
+                AttributeOptionStoreLabel::of('de_de', 'Gross'),
+                AttributeOptionStoreLabel::of('fr_fr', 'Grand'),
+            ]));
         self::assertEquals([
             'entity_type' => 4,
             'attribute_code' => 'size',
             'option' => [
                 'value' => 'large',
                 'label' => 'Large',
+                'sort_order' => 3,
+                'store_labels' => [
+                    [
+                        'store_code' => 'en_gb',
+                        'label' => 'Large'
+                    ],
+                    [
+                        'store_code' => 'en_eu',
+                        'label' => 'Large'
+                    ],
+                    [
+                        'store_code' => 'de_de',
+                        'label' => 'Gross'
+                    ],
+                    [
+                        'store_code' => 'fr_fr',
+                        'label' => 'Grand'
+                    ],
+                ]
             ]
         ], $attributeOption->toJson());
     }


### PR DESCRIPTION
## Overview 

This PR aims to add store labels to the magento data model in order to all attribute option labels to be persisted per store. It will also add support for sort order.

## Tasks
- [x] Model Store Labels
- [x] Add to Attirbtue Options
- [x] Expose Sort Order in magento Attribute option model