### PR TITLE
Add store codes to the commandGroupId

### DIFF
--- a/src/Command/SaveProductCommand.php
+++ b/src/Command/SaveProductCommand.php
@@ -10,8 +10,9 @@ final class SaveProductCommand extends Command
     {
         $command = new self;
         $command->productData = $productData;
+        $storeCode = $command->productData->getStoreCode();
         return $command
-            ->withCommandGroupId("product.{$productData->getSku()}")
+            ->withCommandGroupId("product.$storeCode.{$productData->getSku()}")
             ->withShardingKey($productData->getSku());
     }
 

--- a/test/unit/Command/SaveProductCommandTest.php
+++ b/test/unit/Command/SaveProductCommandTest.php
@@ -16,7 +16,7 @@ class SaveProductCommandTest extends TestCase
         self::assertEquals([
             '@store' => 'admin',
             '@shardingKey' => 'test-product',
-            '@commandGroupId' => 'product.test-product',
+            '@commandGroupId' => 'product.admin.test-product',
             'sku' => 'test-product',
             'product' => [
                 'sku' => 'test-product',


### PR DESCRIPTION
## Overview

Based on a issue observed by a client it seems that there are cases whereby commands are dropped if two different stores recieved updates from the same source. For example two different eu stores sharing the same price segment since timestamps of commands in the same command group undergo an idempotency check adding the store id will ensure that products that belong to specific store are treated as individual commands.

## Task 
- [x] Ensure that store codes are used for save product commands.
