### PR TITLE
Optional customer id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_install:
   - if [[ -n $PACKAGIST_TOKEN ]]; then composer config http-basic.repo.packagist.com token $PACKAGIST_TOKEN; fi
 cache:
   directories: $HOME/.composer/cache
-before_script: composer install --no-interaction --dev
+before_script:
+  - phpenv config-add travis.php.ini
+  - composer install --no-interaction --dev
+
 script: vendor/bin/phpunit --coverage-clover=coverage.xml
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/src/Command/SaveCustomerCommand.php
+++ b/src/Command/SaveCustomerCommand.php
@@ -31,7 +31,7 @@ final class SaveCustomerCommand extends Command
 
         $json = $parentJson + ['customer' => $this->customerData->toJson()];
 
-        if ($this->customerData->getId()) {
+        if ($this->customerData->getId() !== null) {
            $json += ['customerId' => (int) $this->customerData->getId()];
         }
 

--- a/src/Command/SaveCustomerCommand.php
+++ b/src/Command/SaveCustomerCommand.php
@@ -27,10 +27,15 @@ final class SaveCustomerCommand extends Command
 
     public function toJson(): array
     {
-        return parent::toJson() + [
-            'customerId' => (int) $this->customerData->getId(),
-            'customer' => $this->customerData->toJson(),
-        ];
+        $parentJson = parent::toJson();
+
+        $json = $parentJson + ['customer' => $this->customerData->toJson()];
+
+        if ($this->customerData->getId()) {
+           $json += ['customerId' => (int) $this->customerData->getId()];
+        }
+
+        return $json;
     }
 
     /** @var CustomerData */

--- a/src/CustomerData.php
+++ b/src/CustomerData.php
@@ -42,7 +42,6 @@ final class CustomerData implements ValueObject
     public function toJson(): array
     {
         $json = [
-            'id' => (int) $this->id,
             'email' => $this->email,
             'firstname' => $this->firstname,
             'lastname' => $this->lastname,
@@ -64,6 +63,10 @@ final class CustomerData implements ValueObject
             'extension_attributes' => $this->extensionAttributes->toJson(),
             'custom_attributes' => $this->customAttributes->toJson()
         ];
+
+        if ($this->id) {
+            $json['id'] = $this->id;
+        }
 
         // optionals
         if ($this->addresses->count()) {

--- a/src/CustomerData.php
+++ b/src/CustomerData.php
@@ -64,7 +64,7 @@ final class CustomerData implements ValueObject
             'custom_attributes' => $this->customAttributes->toJson()
         ];
 
-        if ($this->id) {
+        if ($this->id !== null) {
             $json['id'] = $this->id;
         }
 

--- a/test/unit/Command/SaveCustomerCommandTest.php
+++ b/test/unit/Command/SaveCustomerCommandTest.php
@@ -10,13 +10,13 @@ class SaveCustomerCommandTest extends TestCase
 {
     public function testToJson()
     {
-        $command = SaveCustomerCommand::of(CustomerData::of('test@amp.co'))
+        $command = SaveCustomerCommand::of(CustomerData::of('test@amp.co')->withId(1))
         ->withTimestamp(1509530316);
         self::assertEquals([
             '@timestamp' => (float)1509530316,
-            'customerId' => 0,
+            'customerId' => 1,
             'customer' => [
-                'id' => null,
+                'id' => 1,
                 'email' => 'test@amp.co',
                 'firstname' => null,
                 'lastname' => null,

--- a/test/unit/CustomerDataTest.php
+++ b/test/unit/CustomerDataTest.php
@@ -17,7 +17,6 @@ class CustomerDataTest extends TestCase
     public function testToJson()
     {
         self::assertSame([
-            'id' => 0,
             'email' => 'test@amp.co',
             'firstname' => null,
             'lastname' => null,
@@ -246,7 +245,6 @@ class CustomerDataTest extends TestCase
     public function testGetters()
     {
         $customer = CustomerData::of('test@amp.co')
-            ->withId(1)
             ->withStoreId(1)
             ->withWebsiteId(1)
             ->withGroupId(1)
@@ -295,7 +293,6 @@ class CustomerDataTest extends TestCase
             );
 
         self::assertEquals([
-            'id' => $customer->getId(),
             'email' => $customer->getEmail(),
             'firstname' => $customer->getFirstname(),
             'lastname' => $customer->getLastname(),
@@ -318,6 +315,7 @@ class CustomerDataTest extends TestCase
             'extension_attributes' => $customer->getExtensionAttributes()->toJson(),
             'custom_attributes' => $customer->getCustomAttributes()->toJson()
         ], $customer->toJson());
+        self::assertNull($customer->getId());
     }
 
     public function testEqualsComplete()

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = -1


### PR DESCRIPTION
## Overview

This PR aims to ensure that optional customer ids are possible since there are some situations whereby a customer Id may not be required e.g. In the case that a custom endpoint will be using the payload in another fashion (ie. user code lookups) and therefore if a customer Id is specified then it should still work as expected and if not it will be ignored.

## Tasks
- [x] Make the customer id optional in the data model
- [x] Make the customer id optional in command