### PR TITLE
Make attribute codes be lowercase

### DIFF
--- a/src/AttributeData.php
+++ b/src/AttributeData.php
@@ -95,7 +95,7 @@ final class AttributeData implements ValueObject
 
     private function __construct(string $attributeCode, string $frontendInput)
     {
-        $this->attributeCode = $attributeCode;
+        $this->attributeCode = strtolower($attributeCode);
         $this->frontendInput = $frontendInput;
     }
 }

--- a/src/AttributeSet/AttributeData.php
+++ b/src/AttributeSet/AttributeData.php
@@ -9,7 +9,7 @@ final class AttributeData implements ValueObject
     public static function of(string $code): self
     {
         $attributeData = new self;
-        $attributeData->code = $code;
+        $attributeData->code = strtolower($code);
         return $attributeData;
     }
 

--- a/test/unit/AttributeDataTest.php
+++ b/test/unit/AttributeDataTest.php
@@ -21,6 +21,15 @@ class AttributeDataTest extends TestCase
             'default_frontend_label' => 'Diameter',
             'scope' => AttributeScope::GLOBAL,
         ], $attribute->toJson());
+
+        $attribute = AttributeData::of('Diameter', FrontendInput::TEXT, 'Diameter');
+        self::assertEquals([
+            'attribute_code' => 'diameter',
+            'is_required' => false,
+            'frontend_input' => 'text',
+            'default_frontend_label' => 'Diameter',
+            'scope' => AttributeScope::GLOBAL,
+        ], $attribute->toJson());
     }
 
     public function testWithers()

--- a/test/unit/AttributeSet/AttributeGroupTest.php
+++ b/test/unit/AttributeSet/AttributeGroupTest.php
@@ -30,7 +30,7 @@ class AttributeGroupTest extends TestCase
             ->withAttributes(AttributeDataSet::of([
                 AttributeData::of('size')->withSortOrder(1),
                 AttributeData::of('color')->withSortOrder(3),
-                AttributeData::of('density')->withSortOrder(1),
+                AttributeData::of('Density')->withSortOrder(1),
             ]))->withAttribute(AttributeData::of('volume')->withSortOrder(19));
 
         self::assertTrue(AttributeDataSet::of([


### PR DESCRIPTION
Magento only accepts lowercase attribute codes. Akeneo applies no such restriction,
but it makes little difference to enforce it here.