### PR TITLE
Make source item data set an IteratorAggregate

### DIFF
--- a/src/Inventory/SourceItemDataSet.php
+++ b/src/Inventory/SourceItemDataSet.php
@@ -6,7 +6,7 @@ use SnowIO\Magento2DataModel\Command\SaveSourceItemsCommand;
 use SnowIO\Magento2DataModel\MagentoDataException;
 use SnowIO\Magento2DataModel\SetTrait;
 
-class SourceItemDataSet
+class SourceItemDataSet implements \IteratorAggregate
 {
     use SetTrait;
 


### PR DESCRIPTION
## Overview 

Quick fix to the magento 2 data model we need to ensure that the source item data set is an iterator aggregate