### PR TITLE
Add store scope to deletion commands

### DIFF
--- a/src/Command/DeleteProductCommand.php
+++ b/src/Command/DeleteProductCommand.php
@@ -18,6 +18,18 @@ final class DeleteProductCommand extends Command
         return $this->sku;
     }
 
+    public function getStoreCode(): string
+    {
+        return $this->storeCode;
+    }
+
+    public function withStoreCode(string $storeCode): self
+    {
+        $result = clone $this;
+        $result->storeCode = $storeCode;
+        return $result;
+    }
+
     public function equals($object): bool
     {
         return $object instanceof self
@@ -27,12 +39,13 @@ final class DeleteProductCommand extends Command
 
     public function toJson(): array
     {
-        return parent::toJson() + [
+        return parent::toJson() + array_merge([
             'sku' => $this->sku,
-        ];
+        ], ($this->storeCode ?  ['@store' => $this->storeCode] : []));
     }
 
     private $sku;
+    private $storeCode;
 
     private function __construct()
     {

--- a/test/unit/Command/DeleteProductCommandTest.php
+++ b/test/unit/Command/DeleteProductCommandTest.php
@@ -19,6 +19,18 @@ class DeleteProductCommandTest extends TestCase
         ], $command->toJson());
     }
 
+    public function testStoreCode()
+    {
+        $command = DeleteProductCommand::of('test-product')->withStoreCode('admin')->withTimestamp(123);
+        self::assertEquals([
+            '@timestamp' => (float)123,
+            '@store' => 'admin',
+            '@shardingKey' => 'test-product',
+            '@commandGroupId' => 'product.test-product',
+            'sku' => 'test-product',
+        ], $command->toJson());
+    }
+
     public function testAccessors()
     {
         $command = DeleteProductCommand::of('test-product');


### PR DESCRIPTION
## Overview 

We need to add store scope deletions for products so that when a product is nolonger salable in a store it can be removed on that store

## Tasks

- [x] Update tests
- [x] Ensure store attribute exists 