### PR TITLE
Make store optional in save source items command

### DIFF
--- a/src/Command/SaveSourceItemsCommand.php
+++ b/src/Command/SaveSourceItemsCommand.php
@@ -27,10 +27,16 @@ class SaveSourceItemsCommand extends Command
 
     public function toJson(): array
     {
-        return parent::toJson() + [
+        $json = parent::toJson() + [
             "sourceItems" => $this->sourceItems->toJson(),
             "@store" => $this->store,
         ];
+
+        if ($this->store) {
+            $json["@store"] = $this->store;
+        }
+
+        return $json;
     }
 
     /** @var SourceItemDataSet */


### PR DESCRIPTION
## Overview

The store parameter is not really required so if it not give it should be ignored

## Tasks
- [x] Make store optional